### PR TITLE
feat: Implement fragment web preview and hint component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { TRPCReactProvider } from "@/trpc/client";
@@ -20,11 +19,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <TRPCReactProvider>
-      <html lang="en" suppressHydrationWarning>
-        <body
-          className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-        >
+    <html lang="en" suppressHydrationWarning>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+      >
+        <TRPCReactProvider>
           <ThemeProvider
             attribute="class"
             defaultTheme="system"
@@ -34,8 +33,8 @@ export default function RootLayout({
             <Toaster />
             {children}
           </ThemeProvider>
-        </body>
-      </html>
-    </TRPCReactProvider>
+        </TRPCReactProvider>
+      </body>
+    </html>
   );
 }

--- a/src/components/hint.tsx
+++ b/src/components/hint.tsx
@@ -1,0 +1,32 @@
+"use client";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface Props {
+  children: React.ReactNode;
+  text: string;
+  side?: "top" | "bottom" | "left" | "right";
+  align?: "start" | "center" | "end";
+}
+
+export const Hint = ({
+  children,
+  text,
+  side = "top",
+  align = "center",
+}: Props) => {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent side={side} align={align}>
+          <p className="font-semibold capitalize">{text}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/src/inngest/function.ts
+++ b/src/inngest/function.ts
@@ -36,7 +36,7 @@ export const codeAgentFunction = inngest.createFunction(
       //   model: "gpt-4.1-mini-2025-04-14",
       // }),
       model: gemini({
-        model: "gemini-2.5-pro",
+        model: "gemini-2.5-flash",
       }),
       tools: [
         createTool({

--- a/src/modules/projects/ui/components/fragment-web.tsx
+++ b/src/modules/projects/ui/components/fragment-web.tsx
@@ -1,0 +1,71 @@
+import { Fragment } from "@/generated/prisma";
+import { useState } from "react";
+import { ExternalLinkIcon, RefreshCcwIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Hint } from "@/components/hint";
+
+interface Props {
+  data: Fragment;
+}
+
+export const FragmentWeb = ({ data }: Props) => {
+  const [fragmentKey, setFragmentKey] = useState(0);
+  const [copied, setCopied] = useState(false);
+
+  const onRefresh = () => {
+    setFragmentKey((prev) => prev + 1);
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(data.sandboxUrl);
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
+
+  return (
+    <div className="flex flex-col w-full h-full">
+      <div className="p-2 border-b bg-sidebar text-sidebar-foreground flex items-center gap-x-2">
+        <Hint text="Refresh" side="bottom" align="start">
+          <Button size="sm" variant="outline" onClick={onRefresh}>
+            <RefreshCcwIcon className="text-sidebar-foreground" />
+          </Button>
+        </Hint>
+        <Hint text="Click to copy" side="bottom">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleCopy}
+            disabled={!data.sandboxUrl || copied}
+            className="flex-1 justify-start text-start font-normal text-sidebar-foreground"
+          >
+            <span className="truncate">{data.sandboxUrl}</span>
+          </Button>
+        </Hint>
+        <Hint text="Open in a new tab" side="bottom" align="start">
+          <Button
+            size="sm"
+            disabled={!data.sandboxUrl}
+            variant={"outline"}
+            onClick={() => {
+              if (!data.sandboxUrl) {
+                return;
+              }
+              window.open(data.sandboxUrl, "_blank");
+            }}
+          >
+            <ExternalLinkIcon className="text-sidebar-foreground" />
+          </Button>
+        </Hint>
+      </div>
+      <iframe
+        key={fragmentKey}
+        className=" w-full h-full"
+        sandbox="allow-forms allow-scripts allow-same-origin"
+        loading="lazy"
+        src={data.sandboxUrl}
+      />
+    </div>
+  );
+};

--- a/src/modules/projects/ui/views/project-view.tsx
+++ b/src/modules/projects/ui/views/project-view.tsx
@@ -9,6 +9,7 @@ import { MessageContainer } from "../components/messages-container";
 import { Suspense, useState } from "react";
 import { Fragment } from "@/generated/prisma";
 import { ProjectHeader } from "../components/project-header";
+import { FragmentWeb } from "../components/fragment-web";
 
 interface Props {
   projectId: string;
@@ -41,7 +42,7 @@ export const ProjectView = ({ projectId }: Props) => {
           minSize={50}
           className="flex flex-col min-w-0"
         >
-          TODO : Preview
+          {!!activeFragment && <FragmentWeb data={activeFragment} />}
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>


### PR DESCRIPTION
- Added a new Hint component for displaying tooltips.
- Implemented FragmentWeb component to display web previews using iframes.
- Integrated FragmentWeb into the ProjectView to show the active fragment.
- Updated the Inngest function to use gemini-2.5-flash model.
- Fixed the layout.tsx to wrap the app with TRPCReactProvider.